### PR TITLE
Deprecate Explorer on web

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "talks": "deno run --allow-all utils/talks.js",
     "explorer": "deno run --allow-all utils/explorer.js",
     "events-ext": "deno run --allow-all utils/events-ext.js",
+    "db-repo": "deno run --allow-all utils/db-repo.js",
     "sync-all": "npm run core && npm run contribs && npm run articles && npm run talks && npm run explorer && npm run events-ext"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "explorer": "deno run --allow-all utils/explorer.js",
     "events-ext": "deno run --allow-all utils/events-ext.js",
     "db-repo": "deno run --allow-all utils/db-repo.js",
-    "sync-all": "npm run core && npm run contribs && npm run articles && npm run talks && npm run explorer && npm run events-ext"
+    "sync-all": "npm run core && npm run contribs && npm run articles && npm run talks && npm run explorer && npm run events-ext && npm run db-repo"
   },
   "dependencies": {
     "@astrojs/tailwind": "^5.1.0",

--- a/src/config.yaml
+++ b/src/config.yaml
@@ -16,8 +16,8 @@ header:
     #  url: /articles
     #- name: Leaderboard
     #  url: /leaderboard
-    - name: Explorer
-      link: explorer
+    #- name: Explorer
+    #  link: explorer
     - name: News
       link: news
     - name: Docs

--- a/src/db-repo.json
+++ b/src/db-repo.json
@@ -1,0 +1,5 @@
+{
+  "count": "550+",
+  "contributors": 30,
+  "stars": 302
+}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -6,6 +6,7 @@ import core from '../core.json';
 import articles from '../articles.json';
 import talks from '../talks.json';
 import explorer from '../explorer.json';
+import dbRepo from '../db-repo.json';
 import { isPast, format } from 'date-fns';
 
 const events = core.events;
@@ -44,15 +45,22 @@ for (const ev of events) {
 					</div>
 				</div>
 			</div>
-			<div class="bg-projects" data-url="https://explorer.web3privacy.info">
-				<div class="title">Explorer</div>
+			<div class="bg-projects relative" data-url="https://github.com/web3privacy/web3privacy/blob/main/README.md#contents">
+				<div class="title">
+					<div class="flex items-center">
+						<div class="icon github small mr-1.5 inline-block"></div>
+						<div class="text-white mt-1 ml-1.5"><a href="https://github.com/web3privacy/web3privacy/blob/main/README.md#contents">Web3 Privacy Database</a></div>
+					</div>
+				</div>
+				<!-- Place this tag where you want the button to render. -->
+				<div class="flex items-center absolute top-4 right-4 text-white opacity-30"><div class="icon star small mr-1.5"></div> {dbRepo.stars}</div>
 				<div class="numbers">
 					<div>
-						<div class="big">{explorer.projects}</div>
+						<div class="big">{dbRepo.count}</div>
 						<div>Projects</div>
 					</div>
 					<div>
-						<div class="big">{explorer.contributors}</div>
+						<div class="big">{dbRepo.contributors}</div>
 						<div>Contributors</div>
 					</div>
 				</div>

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -207,6 +207,11 @@
   .icon.small {
     @apply w-6 h-6;
   }
+
+  .icon.star {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' width='16' height='16' fill='white' class='octicon octicon-star' aria-hidden='true'%3E%3Cpath d='M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.751.751 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Zm0 2.445L6.615 5.5a.75.75 0 0 1-.564.41l-3.097.45 2.24 2.184a.75.75 0 0 1 .216.664l-.528 3.084 2.769-1.456a.75.75 0 0 1 .698 0l2.77 1.456-.53-3.084a.75.75 0 0 1 .216-.664l2.24-2.183-3.096-.45a.75.75 0 0 1-.564-.41L8 2.694Z'%3E%3C/path%3E%3C/svg%3E");
+    background-size: 100% 100%;
+  }
   
   .icon.twitter {
     background-image: url('data:image/svg+xml,<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M23.7895 16.9392L38.6704 0H35.1454L22.2188 14.7051L11.9021 0H0L15.6043 22.2388L0 40H3.52506L17.167 24.4676L28.0646 40H39.9667M4.79734 2.60316H10.2128L35.1427 37.5247H29.7259" fill="%23C0C0C0"/></svg>');

--- a/utils/db-repo.js
+++ b/utils/db-repo.js
@@ -1,0 +1,26 @@
+
+
+// projects count
+const resp = await fetch("https://raw.githubusercontent.com/web3privacy/web3privacy/main/README.md");
+const text = await resp.text();
+const [_, count] = text.match(/([\d\+]+) privacy projects/)
+
+// contributors
+const response = await fetch(`https://api.github.com/repos/web3privacy/web3privacy/contributors`,);
+const repoContributors = await response.json();
+
+// stars
+const respRepo = await fetch('https://api.github.com/repos/web3privacy/web3privacy')
+const repo = await respRepo.json();
+
+const data = {
+    count,
+    contributors: repoContributors.length,
+    stars: repo.stargazers_count,
+}
+
+await Deno.writeTextFile(
+    "./src/db-repo.json",
+    JSON.stringify(data, null, 2),
+  );
+  console.log(`File ./src/db-repo.json saved`);


### PR DESCRIPTION
Our website is supposed to be a place that reflects what we do and is a kind of showcase of our activities.

The Explorer project had only one simple goal and that was to replace the original [Markdown database](https://github.com/web3privacy/web3privacy/blob/main/README.md) that Mykola created. After more than 4 months it is clear that it has **failed to meet that simple goal and there are no prospects of that happening anytime soon**.

The original Markdown database is still being modified, gaining stars and is one of the most valuable assets W3PN has. Presenting a non-functioning Explorer instead is a big mistake, which brings a lot of confusion and inconsistency.

For these reasons, I suggest replacing Explorer on the site with this original database on Github and linking everyone there instead. This should be the case until the original markdown document is deprecated and Explorer replaces it, in its entirety **including data maintenance**.

## Specific steps
- removing the Explorer link from the menu
- the middle panel on the main page, which presented Explorer, will now be presenting the GitHub document

[Preview link](https://web-git-feat-remove-explorer-web3privacy.vercel.app/)

### Preview

<img width="518" alt="Screenshot 2024-02-27 at 8 06 51" src="https://github.com/web3privacy/web/assets/67269/a101ff45-cd45-4f65-bf6e-2c1974ce9dee">
