### PR TITLE
 Dependency migration - jsr@std instead of deno.land

### DIFF
--- a/utils/cleanup-flags.js
+++ b/utils/cleanup-flags.js
@@ -1,4 +1,4 @@
-import { join } from "https://deno.land/std@0.216.0/path/join.ts";
+import { join } from "jsr:@std/path@0.224.0";
 
 const src = JSON.parse(await Deno.readTextFile("./src/core.json"));
 const usedFlags = [...new Set(src.events.map((e) => e.country + ".svg"))];

--- a/utils/contributors.js
+++ b/utils/contributors.js
@@ -1,4 +1,4 @@
-import "https://deno.land/std@0.206.0/dotenv/load.ts";
+import "jsr:@std/dotenv@0.224.0";
 
 const contributorRepos = [
   // main repos

--- a/utils/gen-images.js
+++ b/utils/gen-images.js
@@ -1,5 +1,5 @@
 import { run } from "https://deno.land/x/run_simple/mod.ts";
-import { join } from "https://deno.land/std@0.208.0/path/mod.ts";
+import { join } from "jsr:@std/path@0.224.0";
 
 const IMG_DIR = "./public/gen-img/events";
 


### PR DESCRIPTION
I discovered that the Deno Standard Library (std) library by deno.land will be moved to JSR before the end of 2024

In this PR all relevant std packages have been switched to jsr
