### PR TITLE
chore: update Labyrinth links

### DIFF
--- a/src/core.json
+++ b/src/core.json
@@ -128,7 +128,7 @@
       "name": "Labyrinth",
       "imageUrl": "https://web3privacy.info/membersLogo/labyrinth.png",
       "refs": {
-        "website": "https://www.labyrinth.technology",
+        "website": "https://www.labyrinth.ac",
         "twitter": "Labyrinth_HQ"
       }
     },
@@ -1014,7 +1014,7 @@
     {
       "id": "amit-chaudhary",
       "name": "Amit Chaudhary",
-      "caption": "Founder of [Labyrinth](https://www.labyrinth.technology/)",
+      "caption": "Founder of [Labyrinth](https://www.labyrinth.ac/)",
       "country": "in",
       "refs": {
         "twitter": "amitchax"


### PR DESCRIPTION
We https://github.com/Labyrinth-tech have changed our domain